### PR TITLE
add what should be the active link once github pages updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ## Link and Screenshot
 
-- Link: 
+- Link: https://dylancas.github.io/js-pw-genny/
 
 ![screenshot](./Develop/assets/completed.png)
 


### PR DESCRIPTION
Github pages seems frozen in time, unable to publish updated files. Inserted what should be the active link once it is finished.